### PR TITLE
FIx Terraform  Apply Error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy" "role_policy" {
 
 data "aws_iam_policy_document" "role_policy" {
   statement {
-    sid = "ITMC_Integration_Access_Policy"
+    sid = "IntegrationAccessPolicy"
     effect = "Allow"
     actions = [
                 "iam:GetAccessKeyLastUsed",


### PR DESCRIPTION
```
╷
│ Error: Error putting IAM role policy IT-Management-Cloud-Integration-Role-Policy: MalformedPolicyDocument: Statement IDs (SID) must be alpha-numeric. Check that your input satisfies the regular expression [0-9A-Za-z]*
│ 	status code: 400, request id: 0e89de32-2637-4e1c-afd4-c0899d8c8123
│
│   with module.itmc-integration.aws_iam_role_policy.role_policy,
│   on .terraform/modules/itmc-integration/main.tf line 34, in resource "aws_iam_role_policy" "role_policy":
│   34: resource "aws_iam_role_policy" "role_policy" {
```