### PR TITLE
chore(security): add least-privilege permissions to documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,9 +2,14 @@ name: Generate terraform docs
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
         with:
           working-dir: .
           config-file: .terraform-docs.yml


### PR DESCRIPTION
## Summary

Closes 1 CodeQL `actions/missing-workflow-permissions` alert on `.github/workflows/documentation.yml` by declaring explicit least-privilege `GITHUB_TOKEN` permissions.

## Change

- Set top-level `permissions: contents: read` (default-deny baseline for all jobs).
- Override the `docs` job with `permissions: contents: write` — required because the workflow uses `terraform-docs/gh-actions@main` with `git-push: "true"`, which commits the regenerated docs back to the PR branch.

```yaml
permissions:
  contents: read

jobs:
  docs:
    permissions:
      contents: write
```

A plain top-level `contents: read` would have broken the workflow's existing `git-push` behavior, so the per-job override is required.

## Follow-up (separate PR)

`terraform-docs/gh-actions@main` is pinned to a mutable tag. CodeQL/OpenSSF best practice is to pin third-party actions to a commit SHA. Out of scope for this security fix but worth tracking.

## Test plan

- [ ] CI passes on this PR
- [ ] `docs` job still successfully renders + pushes terraform-docs updates on subsequent PRs
- [ ] CodeQL `actions/missing-workflow-permissions` alert auto-closes after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moneyforward-i/terraform-aws-admina-integration/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->